### PR TITLE
sklearn.externals.six is removed, changed into six

### DIFF
--- a/Chapter_12_Ensemble_Methods/utils.py
+++ b/Chapter_12_Ensemble_Methods/utils.py
@@ -47,7 +47,7 @@ def plot_model(X, y, model, fix_margins=True):
     pyplot.show()
 
 def display_tree(dt):
-    from sklearn.externals.six import StringIO  
+    from six import StringIO  
     from IPython.display import Image  
     from sklearn.tree import export_graphviz
     import pydotplus

--- a/Chapter_9_Decision_Trees/utils.py
+++ b/Chapter_9_Decision_Trees/utils.py
@@ -39,7 +39,7 @@ def plot_model(X, y, model, size_of_points=100):
     pyplot.show()
     
 def display_tree(dt):
-    from sklearn.externals.six import StringIO  
+    from six import StringIO  
     from IPython.display import Image  
     from sklearn.tree import export_graphviz
     import pydotplus


### PR DESCRIPTION
sklearn.externals.six in utils.py in chapters 9, 12 is removed and doesn't work.  
Changed into new module "six"
`from six import StringIO`